### PR TITLE
Paired reads orientation generation behavior

### DIFF
--- a/source/output_file_writer.py
+++ b/source/output_file_writer.py
@@ -183,8 +183,10 @@ class OutputFileWriter:
         if read2 is not None and orientation is True:
             (read2, quality2) = (read2.reverse_complement(), qual2[::-1])
         elif read2 is not None and orientation is False:
-            (read1, quality1) = (read2.reverse_complement(), qual2[::-1])
+            read2_tmp = read2
+            qual2_tmp = qual2
             (read2, quality2) = (read1, qual1)
+            (read1, quality1) = (read2_tmp.reverse_complement(), qual2_tmp[::-1])
 
         if self.fasta_instead:
             self.fq1_buffer.append('>' + read_name + '/1\n' + str(read1) + '\n')


### PR DESCRIPTION
Hello. I have noticed wrong behavior of paired read simulation.  Read2 when `orientation==False` equal to read1.  This also seems to be related to https://github.com/ncsa/NEAT/issues/17 issue.

Since if `write_fastq_record()` function must simulate random(50/50) Illumina adapter ligation as described for example
[here](https://seekdeep.brown.edu/illumina_paired_info.html) or [here](https://www.biostars.org/p/244732/ ) I change `write_fastq_record()` function accordingly to this behavior. 

Thank you for maintaining this project.

Kirill. 