### PR TITLE
Minor changes to output_file_writer

### DIFF
--- a/neat/read_simulator/runner.py
+++ b/neat/read_simulator/runner.py
@@ -325,7 +325,8 @@ def read_simulator_runner(config: str, output: str):
                                             options,
                                             local_fasta_file)
         vcf_files.append(local_variant_file)
-        fasta_files.extend(local_fasta_file)
+        if options.produce_fasta:
+            fasta_files.extend(local_fasta_file)
 
         if options.produce_fastq or options.produce_bam:
             read1_fastq, read2_fastq = \

--- a/neat/read_simulator/utils/local_file_writer.py
+++ b/neat/read_simulator/utils/local_file_writer.py
@@ -42,7 +42,8 @@ def write_local_file(vcf_filename: str or Path,
         filtered_by_discard = 0
         n_added = 0
 
-        local_fasta = LocalFasta(fasta_filename, reference, options)
+        if options.produce_fasta:
+            local_fasta = LocalFasta(fasta_filename, reference, options)
         for loc in variant_data.variant_locations:
             for variant in variant_data[loc]:
                 if not variant.is_input:
@@ -98,7 +99,11 @@ def write_local_file(vcf_filename: str or Path,
 
     _LOG.debug(f"Added {n_added} mutations to the reference.")
 
-    return local_fasta.filenames
+    if options.produce_fasta:
+        return local_fasta.filenames
+    else:
+        return None
+
 
 class LocalFasta:
     """
@@ -116,7 +121,6 @@ class LocalFasta:
         self.names = [f"{reference.id}_{k+1}" for k in range(options.ploidy)]
         self.mutated_references = [deepcopy(mutable_ref_seq) for _ in range(options.ploidy)]
         self.offset = [0] * options.ploidy
-
 
     def add_variant(self, variant):
         """

--- a/neat/read_simulator/utils/output_file_writer.py
+++ b/neat/read_simulator/utils/output_file_writer.py
@@ -246,8 +246,13 @@ class OutputFileWriter:
                 current_index = [read2_keys.index(x) for x in read2_keys if current_key in x][0]
                 read = fastq_indexes[current_index][1][current_key]
                 SeqIO.write(read, fq2, 'fastq')
+
         if not paired_ended:
-            Path.unlink(self.fastq2_fn)
+
+            fastq2_path = Path(self.fastq2_fn)
+
+            if fastq2_path.exists():
+                fastq2_path.unlink()
 
     def output_bam_file(self, reads_files: list, contig_dict: dict):
         """

--- a/neat/read_simulator/utils/output_file_writer.py
+++ b/neat/read_simulator/utils/output_file_writer.py
@@ -100,7 +100,7 @@ class OutputFileWriter:
         # Set up filenames based on booleans
         files_to_write = []
         if self.write_fasta:
-            if options.ploidy > 1 and options.fasta_per_ploid:
+            if options.ploidy > 1:
                 self.fasta_fns = [options.output.parent / f'{options.output.stem}_ploid{i+1}.fasta.gz'
                                   for i in range(options.ploidy)]
             else:


### PR DESCRIPTION
- Removed instances of fasta_per_ploid, since we deleted this flag
- Added a check if paired_ended mode is off (if the file for the second FASTQ doesn’t exist before deleting it)




