### PR TITLE
Instantiate `alt_count` when there is no FORMAT column

### DIFF
--- a/neat/read_simulator/utils/vcf_func.py
+++ b/neat/read_simulator/utils/vcf_func.py
@@ -232,6 +232,7 @@ def parse_input_vcf(input_dict: dict[str: ContigVariants],
                 else:
                     # If there was no format column, there's no sample column, so we'll generate one
                     format_column = "GT"
+                    alt_count = len(record[4].split(';'))
                     genotype = pick_ploids(ploidy, homozygous_frequency, alt_count, options.rng)
                     normal_sample_field = get_genotype_string(genotype)
 


### PR DESCRIPTION
Currently, when VCF file has no `FORMAT` column, function `pick_ploids` was called with `alt_count` as one of its in put parameters. But `alt_count` was not scope in the statement.