### PR TITLE
Bug fix for issue 132

### DIFF
--- a/neat/read_simulator/utils/generate_reads.py
+++ b/neat/read_simulator/utils/generate_reads.py
@@ -402,7 +402,6 @@ def generate_reads(
     if options.produce_bam:
         # this will give us the proper read order of the elements, for the sam. They are easier to sort now
         properly_paired_reads = sorted(properly_paired_reads)
-        singletons = sorted(singletons)
         sam_order = properly_paired_reads + singletons
 
         with open_output(reads_pickle) as reads:


### PR DESCRIPTION
[singletons](https://github.com/ncsa/NEAT/blob/374f415c6b34a590e1f1a9f3d847b4eccea36ea5/neat/read_simulator/utils/generate_reads.py#L396) are a list of tuples that have `None` in it. Python cannot perform `sorted([(3, None), (2, None), (1, None)])`