### PR TITLE
Fix genomic coordinate incorrectly used as array index in quality array update

### DIFF
--- a/neat/read_simulator/utils/read.py
+++ b/neat/read_simulator/utils/read.py
@@ -232,7 +232,7 @@ class Read:
                 self.update_quality_array(
                     reference_length,
                     alternate,
-                    location,
+                    position,
                     "mutation",
                     quality_scores,
                     qual_score


### PR DESCRIPTION
In `read_simulator.utils`, `apply_mutations` passed the genomic coordinates instead of the relative location of the mutation in the simulated read to `update_quality_array`, causing wrong or no quality scores to be updated. This commit corrects it by passing the relative location.