### PR TITLE
fixing stitch and no fastq

### DIFF
--- a/neat/read_simulator/utils/generate_reads.py
+++ b/neat/read_simulator/utils/generate_reads.py
@@ -268,10 +268,14 @@ def generate_reads(
         )
 
         read_1.mutations = find_applicable_mutations(read_1, contig_variants)
+        if options.produce_fastq:
+            fastq_handle = ofw.files_to_write[ofw.fq1]
+        else:
+            fastq_handle = None
         read_1.finalize_read_and_write(
             error_model,
             qual_model,
-            ofw.files_to_write[ofw.fq1],
+            fastq_handle,
             options.quality_offset,
             options.produce_fastq,
             options.rng
@@ -303,10 +307,14 @@ def generate_reads(
 
             read_2.mutations = find_applicable_mutations(read_2, contig_variants)
 
+            if options.produce_fastq:
+                fastq_handle = ofw.files_to_write[ofw.fq2]
+            else:
+                fastq_handle = None
             read_2.finalize_read_and_write(
                 error_model,
                 qual_model,
-                ofw.files_to_write[ofw.fq2],
+                fastq_handle,
                 options.quality_offset,
                 options.produce_fastq,
                 options.rng

--- a/neat/read_simulator/utils/output_file_writer.py
+++ b/neat/read_simulator/utils/output_file_writer.py
@@ -80,6 +80,7 @@ class OutputFileWriter:
         self.vcf_header = vcf_header
         self.bam_header = bam_header
         self.vcf_format = vcf_format
+        self.tmp_dir = options.temp_dir_path
 
         file_handles: dict[Path, Any] = {}
 

--- a/neat/read_simulator/utils/split_inputs.py
+++ b/neat/read_simulator/utils/split_inputs.py
@@ -4,7 +4,7 @@ Split a FASTA and NEAT config into per‑contig or fixed‑size chunks ready for
 
 import shutil
 import sys
-import gzip
+import resource
 from pathlib import Path
 from textwrap import wrap
 from typing import Iterator
@@ -83,6 +83,12 @@ def main(options: Options, reference_index: dict) -> tuple[dict, int]:
                 idx += 1
                 written += 1
 
+    # soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    # # plus one for the final file to write
+    # if hard_limit > written + 1 >= soft_limit:
+    #     resource.setrlimit(resource.RLIMIT_NOFILE, (written + 1, hard_limit))
+    # elif written + 1 >= hard_limit:
+    #     raise ValueError("Too many files for psyam merge to work successfully, increase Size parameter and try again.")
     # Report success via the logger instead of printing to stderr
     _LOG.info(f"Generated {written} FASTAs in {options.splits_dir}")
     return split_fasta_dict, written


### PR DESCRIPTION
Fixing the stitching function, which was crashing on "too many open files" with large genomes. Fixed an error where it would not allow you to turn "produce_fastq" off.