### PR TITLE
fix for parallel mode not working

### DIFF
--- a/neat/cli/cli.py
+++ b/neat/cli/cli.py
@@ -45,7 +45,7 @@ class Cli:
             prog="neat", description="Run NEAT components"
         )
         self.parser.add_argument(
-            "--version",
+            "-v", "--version",
             action="version",
             version="%(prog)s {version}".format(version=__version__),
         )

--- a/neat/cli/cli.py
+++ b/neat/cli/cli.py
@@ -1,6 +1,9 @@
 """Implements command line interface used by the package."""
 
 __all__ = ['Cli', 'main', 'run']
+__version__ = "4.3.5"
+__author__ = "Joshua Allen"
+__email__ = "jallen17@illinois.edu"
 
 import argparse
 import importlib
@@ -40,6 +43,11 @@ class Cli:
     def __init__(self):
         self.parser = argparse.ArgumentParser(
             prog="neat", description="Run NEAT components"
+        )
+        self.parser.add_argument(
+            "--version",
+            action="version",
+            version="%(prog)s {version}".format(version=__version__),
         )
         self.parser.add_argument(
             "--no-log",

--- a/neat/read_simulator/runner.py
+++ b/neat/read_simulator/runner.py
@@ -2,7 +2,7 @@
 Runner for generate_reads task
 """
 import logging
-import os
+import shutil
 import subprocess
 import time
 import multiprocessing as mp
@@ -239,7 +239,7 @@ def read_simulator_runner(config: str, output_dir: str, file_prefix: str):
             temp_file = str(options.temp_dir_path / "temp.sorted.vcf.gz")
             subprocess.run(["bcftools", "sort", "-o", temp_file, "-Ob9", str(file)])
             Path(temp_file).is_file()
-            os.rename(temp_file, str(file))
+            shutil.move(temp_file, str(file))
             _LOG.info("Indexing vcf")
             pysam.tabix_index(str(file), preset="vcf", force=force)
 

--- a/neat/read_simulator/utils/options.py
+++ b/neat/read_simulator/utils/options.py
@@ -377,6 +377,12 @@ class Options(SimpleNamespace):
         """
         Some sanity checks and corrections to the options.
         """
+        # Maps YAML keys to internal attribute names (fixes mapping of mode/size parameters across types that would default to contig)
+        if hasattr(self, 'mode'):
+            self.parallel_mode = self.mode
+        if hasattr(self,'size'):
+            self.parallel_block_size = self.size
+
         if not (self.produce_bam or self.produce_vcf or self.produce_fastq):
             _LOG.error('No files would be produced, as all file types are set to false')
             sys.exit(1)


### PR DESCRIPTION
Related to [Issue #231 ](https://github.com/ncsa/NEAT/issues/231), when setting mode to size it always runs in contig mode. There is a discrepancy across scripts in the expected args for mode vs parallel_mode and parallel_block_size vs size. I added mapping to the options.py file to account for this, and am now able to run using size mode successfully.