### PR TITLE
RNG bug found in testing.

### DIFF
--- a/neat/read_simulator/utils/options.py
+++ b/neat/read_simulator/utils/options.py
@@ -266,7 +266,7 @@ class Options(SimpleNamespace):
 
         # Update items to config or default values
         base_options.__dict__.update(final_args)
-        base_options.set_random_seed()
+        base_options.rng = base_options.set_random_seed()
 
         # Some options checking to clean up the args dict
         base_options.check_options()


### PR DESCRIPTION
This bug was found during testing. The old code does not store the RNG value into `base_options.rng`, which could influence output depending on what seed the user provides. I might need this double-checked, though! 