### PR TITLE
Fix infinite loop when contig is shorter than read_len

### DIFF
--- a/neat/read_simulator/utils/generate_reads.py
+++ b/neat/read_simulator/utils/generate_reads.py
@@ -183,6 +183,13 @@ def generate_reads(
     # _LOG.info(f'Sampling reads for thread {thread_index}...')
     start_time = time.time()
 
+    if len(reference) < options.read_len:
+        _LOG.warning(
+            f"Contig '{contig_name}' (length {len(reference)}) is shorter than read_len "
+            f"({options.read_len}). Skipping contig."
+        )
+        return []
+
     # _LOG.debug("Covering dataset.")
     t = time.time()
     reads = cover_dataset(


### PR DESCRIPTION
When read_len exceeds a contig's length, cover_dataset enters an infinite loop because no fragment ever satisfies the length check on line 78, so read_count never increments. Add an early-return guard in generate_reads that skips the contig with a WARNING log instead of hanging.