### PR TITLE
Fix indel position offset in paired-end reverse reads

### DIFF
--- a/neat/read_simulator/utils/generate_reads.py
+++ b/neat/read_simulator/utils/generate_reads.py
@@ -272,6 +272,7 @@ def generate_reads(
             end_point=read1[1] + ref_start,
             padding=actual_padding,
             run_read_len=options.read_len,
+            segment_start=read1[0] + ref_start,
             is_paired=options.paired_ended,
         )
 
@@ -309,6 +310,7 @@ def generate_reads(
                 end_point=read2[1] + ref_start,
                 padding=actual_padding,
                 run_read_len=options.read_len,
+                segment_start=start_coordinate + ref_start,
                 is_reverse=True,
                 is_paired=options.paired_ended
             )

--- a/neat/read_simulator/utils/read.py
+++ b/neat/read_simulator/utils/read.py
@@ -50,6 +50,7 @@ class Read:
                  end_point: int,
                  padding: int,
                  run_read_len: int,
+                 segment_start: int = None,
                  is_reverse: bool = False,
                  is_paired: bool = False):
 
@@ -63,6 +64,9 @@ class Read:
         self.end_point = end_point
         self.padding = padding
         self.run_read_length = run_read_len
+        # segment_start is the reference coordinate of reference_segment[0], which may be
+        # earlier than self.position for reverse reads (padding prepended for deletion headroom).
+        self.segment_start = segment_start if segment_start is not None else position
         self.is_reverse = is_reverse
         self.is_paired = is_paired
 
@@ -202,8 +206,10 @@ class Read:
 
             # Fetch parameters
             qual_score = variant_to_apply.get_qual_score()
-            # Find the position within the read for this variant, cast as a python int, instead of a numpy int
-            position = int(variant_to_apply.get_0_location() - self.position)
+            # Find the position within the reference_segment for this variant. Use segment_start rather
+            # than self.position because for reverse reads the segment begins padding bases before
+            # self.position (leading padding for deletion headroom after reverse_complement).
+            position = int(variant_to_apply.get_0_location() - self.segment_start)
             # Figure out if the variant is in this read. If 'to_mutate' selects any 1, then it is mutated.
             # For diploid animals, for example, this should result in approximately 50% of reads having a
             # given heterozygous mutation and 100% for homozygous mutations.


### PR DESCRIPTION
For read_2 (reverse), the reference_segment is constructed starting `padding` bases before self.position to allow room for deletions after reverse_complement. apply_mutations was computing the intra-segment index using self.position, which caused mutations to be placed padding (= read_len // 5) bases too early in the segment. After reverse_complement this manifested as indels appearing at a different reference coordinate in read_2 than in read_1.

This results in one false positive indel call for each true positive.

Fix: add segment_start attribute to Read, set to the actual reference coordinate of reference_segment[0]. apply_mutations now subtracts segment_start instead of position when computing the index.

Image shows indel in two positions and at one loci all in the +strand reads and in the other all in the - strand reads.

<img width="1765" height="289" alt="image" src="https://github.com/user-attachments/assets/4685cac7-7390-4857-8500-6da3a548daef" />

Correction done with assistance from Claude
