### PR TITLE
Fix stale __version__ in neat/cli/cli.py (4.3.6 → 4.4.1)

### DIFF
--- a/neat/cli/cli.py
+++ b/neat/cli/cli.py
@@ -1,7 +1,7 @@
 """Implements command line interface used by the package."""
 
 __all__ = ['Cli', 'main', 'run']
-__version__ = "4.3.6"
+__version__ = "4.4.1"
 __author__ = "Joshua Allen"
 __email__ = "jallen17@illinois.edu"
 


### PR DESCRIPTION
The 4.4.1 release tag and dist-info metadata are correct, but `neat/cli/cli.py` still hardcodes `__version__ = "4.3.6"`, so `neat -v` reports the wrong version. Confirmed on the bioconda package `neat-4.4.1-pyhdfd78af_0`.