### PR TITLE
Support fractional coverage and fix low-coverage over-sampling (#242)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,22 @@
+# NEAT v4.5.2
+
+Fixed coverage handling at low and fractional depths (issue #242).
+
+Previously no reads were generated at `coverage=1`, and fractional coverage was
+rejected outright: `coverage` was typed as an integer in the config schema, and
+the per-chunk read count was rounded with `math.ceil`.
+
+- `coverage` is now a float with a positive lower bound, so fractional depths
+  (e.g. `0.5` for low-pass simulation) are accepted and zero/negative is
+  rejected.
+- Each chunk's read count is kept as a float expectation and rounded
+  stochastically (`E[reads] == target`) rather than with `ceil`. Rounding every
+  chunk up systematically over-covered — negligible at high depth but dominant
+  at low/fractional coverage. The run's seeded RNG is used, so output remains
+  reproducible. Note: same-seed output now differs from prior versions.
+- A chunk that legitimately rounds to zero reads no longer crashes the uniform
+  sampler.
+
 # NEAT v4.5.1
 
 Removed the `cleanup_splits` and `reuse_splits` config options.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ To run the simulator in multithreaded mode, set the `threads` value in the confi
 
 `read_len`: The length of the reads for the FASTQ (if using). _Integer value, default 151._
 
-`coverage`: Desired coverage depth. _Integer value, default = 10._
+`coverage`: Desired average coverage depth. _Numeric value (fractional allowed, e.g. `0.5` for low-pass simulation), must be > 0, default = 10._
 
 `ploidy`: Desired value for ploidy (# of copies of each chromosome in the organism, where if ploidy > 2, "heterozygous"  mutates floor(ploidy / 2) chromosomes). _Default is 2._
 

--- a/neat/read_simulator/utils/generate_reads.py
+++ b/neat/read_simulator/utils/generate_reads.py
@@ -2,7 +2,6 @@ import heapq
 import logging
 import pickle
 import time
-from math import ceil
 from pathlib import Path
 
 import numpy as np
@@ -23,6 +22,29 @@ __all__ = [
 ]
 
 _LOG = logging.getLogger(__name__)
+
+
+def _stochastic_round(expected_count: float, rng) -> int:
+    """
+    Round a fractional read count to an integer without biasing total coverage.
+
+    Each chunk of the genome computes its own fractional expected read count. Rounding
+    every chunk up (math.ceil) systematically over-covers: the bias is negligible at
+    high coverage but dominates at low or fractional coverage, where a chunk's fair
+    share can be well under one read yet still gets rounded up to a whole read. Rounding
+    the fractional part probabilistically instead makes E[count] == expected_count, so
+    the average coverage matches the requested target at any depth. The run's seeded RNG
+    is used, so output remains reproducible for a given seed.
+
+    :param expected_count: The fractional number of reads this chunk should produce.
+    :param rng: The run's seeded numpy Generator.
+    :return: A non-negative integer read count whose expectation is expected_count.
+    """
+    if expected_count <= 0:
+        return 0
+    floor = int(expected_count)
+    remainder = expected_count - floor
+    return floor + int(rng.random() < remainder)
 
 
 def cover_dataset(
@@ -67,11 +89,15 @@ def cover_dataset(
     # precompute how many reads we want
     # The numerator is the total number of base pair calls needed. Coverage is scaled by
     # responsibility_length, not span_length, so chunks don't over-sample their overlap
-    # region (which is also covered by the next chunk).
+    # region (which is also covered by the next chunk). expected_reads is kept as a float
+    # and rounded stochastically (see _stochastic_round) so that summing across many
+    # chunks does not over-cover — critical for low/fractional coverage.
     if options.paired_ended:
-        number_reads = ceil(responsibility_length * options.coverage / (2 * options.read_len))
+        expected_reads = responsibility_length * options.coverage / (2 * options.read_len)
     else:
-        number_reads = ceil(responsibility_length * options.coverage / options.read_len)
+        expected_reads = responsibility_length * options.coverage / options.read_len
+
+    number_reads = _stochastic_round(expected_reads, options.rng)
 
     if gc_model and not gc_model.is_uniform:
         # CDF-based sampling for GC bias
@@ -124,7 +150,9 @@ def cover_dataset(
         denominator = options.gc_global_mean_weight if getattr(
             options, "gc_global_mean_weight", None
         ) else mean_weight
-        number_reads = ceil(number_reads * mean_weight / denominator)
+        # Re-round from the unscaled float expectation so the GC scaling doesn't compound
+        # a prior rounding step.
+        number_reads = _stochastic_round(expected_reads * mean_weight / denominator, options.rng)
 
         if number_reads == 0:
             return []
@@ -181,6 +209,10 @@ def cover_dataset(
 
 def _uniform_sampling(span_length, number_reads, options, fragment_model, *,
                       max_start=None, responsibility_length=None):
+    # A chunk's stochastically-rounded read count can legitimately be 0 at low/fractional
+    # coverage. Bail early so we don't np.concatenate an empty accumulator list below.
+    if number_reads <= 0:
+        return []
     if span_length <= options.read_len:
         return []
 

--- a/neat/read_simulator/utils/options.py
+++ b/neat/read_simulator/utils/options.py
@@ -61,7 +61,7 @@ class Options(SimpleNamespace):
                  rng_seed: int | None = None,
                  read_len: int = 101,
                  threads: int = 1,
-                 coverage: int = 10,
+                 coverage: float = 10,
                  error_model: Path | None = None,
                  avg_seq_error: float | None = None,
                  rescale_qualities: bool = False,
@@ -143,7 +143,7 @@ class Options(SimpleNamespace):
         self.rng_seed = rng_seed
         self.read_len: int = read_len
         self.threads: int = threads
-        self.coverage: int = coverage
+        self.coverage: float = coverage
         self.error_model: Path | None = error_model
         self.avg_seq_error: float | None = avg_seq_error
         self.rescale_qualities: bool = rescale_qualities
@@ -220,7 +220,7 @@ class Options(SimpleNamespace):
         defs = {
             'reference': (Path, None, 'exists', None),
             'read_len': (int, 151, 10, 1000000),
-            'coverage': (int, 10, 1, 1000000),
+            'coverage': (float, 10, 1e-6, 1000000),
             'error_model': (Path, None, 'exists', None),
             'avg_seq_error': (float, None, 0, 0.3),
             'rescale_qualities': (bool, False, None, None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neat-genreads"
-version = "4.5.1"
+version = "4.5.2"
 description = "NGS Simulation toolkit"
 readme = "README.md"
 authors = ["Joshua Allen <jallen17@illinois.edu>", "Keshav Gandhi <krg3@illinois.edu>"]

--- a/tests/test_read_simulator/test_generate_reads.py
+++ b/tests/test_read_simulator/test_generate_reads.py
@@ -6,7 +6,14 @@ from Bio.SeqRecord import SeqRecord
 
 from neat.models import FragmentLengthModel, SequencingErrorModel, TraditionalQualityModel, GCBiasModel, get_uniform_gc_model
 from neat.read_simulator.utils import Options
-from neat.read_simulator.utils.generate_reads import cover_dataset, overlaps, find_applicable_mutations, generate_reads
+from neat.read_simulator.utils.generate_reads import (
+    cover_dataset,
+    overlaps,
+    find_applicable_mutations,
+    generate_reads,
+    _stochastic_round,
+    _uniform_sampling,
+)
 from neat.read_simulator.utils.read import Read
 from neat.variants.contig_variants import ContigVariants
 from neat.variants import SingleNucleotideVariant
@@ -249,6 +256,102 @@ def test_paired_ended_coverage_accuracy(fragment_mean, target_coverage):
         f"Paired-ended (frag_mean={fragment_mean}) average coverage {avg:.2f}x "
         f"is more than 10% off target {target_coverage}x"
     )
+
+
+# Fractional / low coverage and stochastic rounding (issue #242)
+
+def test_stochastic_round_is_unbiased():
+    """Over many draws the mean of _stochastic_round equals the fractional input."""
+    rng = np.random.default_rng(1234)
+    expected = 0.3
+    n = 200_000
+    draws = [_stochastic_round(expected, rng) for _ in range(n)]
+    assert set(draws) <= {0, 1}, "fractional part in [0,1) should round to floor or floor+1"
+    mean = sum(draws) / n
+    assert abs(mean - expected) < 0.01, f"mean {mean:.4f} biased away from {expected}"
+
+
+def test_stochastic_round_edges():
+    """Whole numbers round to themselves; non-positive inputs yield 0."""
+    rng = np.random.default_rng(0)
+    assert all(_stochastic_round(5.0, rng) == 5 for _ in range(100))
+    assert _stochastic_round(0.0, rng) == 0
+    assert _stochastic_round(-3.0, rng) == 0
+    # The integer part is always retained, plus 0 or 1 from the fractional part.
+    assert all(_stochastic_round(7.4, rng) in (7, 8) for _ in range(100))
+
+
+def test_stochastic_round_reproducible():
+    """Same seed → same sequence of roundings."""
+    a = np.random.default_rng(99)
+    b = np.random.default_rng(99)
+    assert [_stochastic_round(0.5, a) for _ in range(50)] == [_stochastic_round(0.5, b) for _ in range(50)]
+
+
+def test_uniform_sampling_zero_reads_no_crash():
+    """A zero read count must return [] rather than crashing on np.concatenate([])."""
+    options = Options(rng_seed=0)
+    options.read_len = 100
+    options.paired_ended = False
+    options.overwrite_output = True
+    fragment_model = FragmentLengthModel(150, 30)
+    assert _uniform_sampling(1000, 0, options, fragment_model) == []
+
+
+def test_low_coverage_multichunk_unbiased():
+    """Summed across many small chunks, fractional coverage must not over-cover.
+
+    Each chunk's fair share here is 0.75 reads. The old ceil() rounded every chunk up
+    to 1, inflating the total by ~33%. Stochastic rounding should land the aggregate
+    near the true target and well below the ceil result. Regression test for #242.
+    """
+    read_len = 100
+    coverage = 0.5
+    responsibility_length = 150          # expected per chunk = 150 * 0.5 / 100 = 0.75 reads
+    n_chunks = 4000
+    expected_per_chunk = responsibility_length * coverage / read_len
+    target_total = n_chunks * expected_per_chunk
+    ceil_total = n_chunks  # what the old ceil() behaviour would have produced (1 per chunk)
+
+    options = Options(rng_seed=42)
+    options.read_len = read_len
+    options.paired_ended = False
+    options.coverage = coverage
+    options.overwrite_output = True
+    fragment_model = FragmentLengthModel(150, 30)
+    reference = SeqRecord(Seq("A" * 300), id="chr1")
+
+    total_reads = 0
+    for _ in range(n_chunks):
+        reads = cover_dataset(
+            reference, options, fragment_model, None,
+            responsibility_length=responsibility_length,
+        )
+        total_reads += len(reads)
+
+    # Aggregate is within 10% of the true fractional target ...
+    assert abs(total_reads - target_total) / target_total < 0.10, (
+        f"aggregate {total_reads} far from fractional target {target_total}"
+    )
+    # ... and clearly below the systematic over-coverage the old ceil() produced.
+    assert total_reads < 0.9 * ceil_total, (
+        f"aggregate {total_reads} not meaningfully below ceil result {ceil_total}"
+    )
+
+
+def test_fractional_coverage_produces_reads():
+    """cover_dataset handles a single fractional-coverage chunk without error."""
+    options = Options(rng_seed=7)
+    options.read_len = 100
+    options.paired_ended = True
+    options.coverage = 0.5
+    options.overwrite_output = True
+    fragment_model = FragmentLengthModel(300, 30)
+    reference = SeqRecord(Seq("A" * 10_000), id="chr1")
+    reads = cover_dataset(reference, options, fragment_model, None)
+    avg = _compute_avg_coverage(reads, 10_000, paired=True)
+    # Loose bound — single chunk, low depth — just confirm it's in the fractional ballpark.
+    assert 0.2 < avg < 0.8, f"fractional coverage {avg:.3f}x outside expected range"
 
 
 def test_overlaps():

--- a/tests/test_read_simulator/test_options.py
+++ b/tests/test_read_simulator/test_options.py
@@ -214,6 +214,41 @@ def test_check_and_log_error_numeric_out_of_range(capsys):
         Options.check_and_log_error("coverage", 0, 1, 1000000)
 
 
+def test_check_and_log_error_fractional_coverage_ok():
+    """Fractional coverage is accepted under the float schema (issue #242)."""
+    Options.check_and_log_error("coverage", 0.5, 1e-6, 1000000)  # no exception
+
+
+def test_check_and_log_error_zero_coverage_exits():
+    """Zero (or negative) coverage is rejected by the positive lower bound."""
+    with _pytest.raises(SystemExit):
+        Options.check_and_log_error("coverage", 0, 1e-6, 1000000)
+
+
+def test_from_cli_fractional_coverage(tmp_path: _PathAlias):
+    """A YAML config with fractional coverage parses and round-trips the float value."""
+    cfg = _textwrap.dedent(
+        f"""
+        reference: {(_project_root() / 'data' / 'H1N1.fa').as_posix()}
+        read_len: 75
+        coverage: 0.5
+        ploidy: 2
+        paired_ended: false
+        produce_fastq: true
+        rng_seed: 42
+        overwrite_output: true
+        """
+    ).strip() + "\n"
+
+    yml_path = tmp_path / "frac.yml"
+    yml_path.write_text(cfg, encoding="utf-8")
+    outdir = tmp_path / "out"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    opts = Options.from_cli(outdir, "frac", yml_path)
+    assert opts.coverage == 0.5
+
+
 def test_check_and_log_error_choice_valid():
     # The schema's `choice`-type validator isn't currently used by any production
     # option, but we still want it covered. Use a synthetic key name so the test


### PR DESCRIPTION
Fixes #242.

## Problem
No reads were generated at `coverage=1` (and fractional coverage was rejected outright):
- `coverage` was typed as `int` in the config schema, so values like `0.5` failed validation.
- The per-chunk read count was rounded with `math.ceil`, which rounds **every** chunk up. This systematically over-covers — negligible at high depth, but dominant at low/fractional coverage where a chunk's fair share can be well under one read.

## Changes
- **`options.py`**: type `coverage` as `float` with a positive lower bound (`1e-6`), so fractional depths (e.g. `0.5` for low-pass simulation) are accepted and zero/negative is rejected.
- **`generate_reads.py`**: keep each chunk's read count as a float *expectation* and round it **stochastically** (`floor + (rng.random() < frac)`) so `E[reads] == target` per chunk → aggregate coverage is unbiased at any depth. Uses the seeded RNG, so output stays reproducible. Also guards `_uniform_sampling` against a 0-read chunk (previously crashed on `np.concatenate([])`).
- **`README.md`**: document `coverage` as numeric/fractional.

## Tests
- Rounding unbiasedness / edges / reproducibility.
- Zero-read guard.
- 4000-chunk aggregate accuracy at fractional coverage (proves no over-coverage; lands well below the old `ceil` result).
- Fractional config parsing + validation of zero/negative rejection.

Full suite: **790 passed, 3 skipped**. End-to-end on H1N1: `coverage=1` → 88 read-pairs, `coverage=0.5` → 46 (both produced 0 reads before).

## Note
Stochastic rounding changes same-seed output vs. the old `ceil` at all coverages (statistically better, but not byte-identical to prior versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)