### PR TITLE
Handle IUPAC ambiguity codes in the reference (#291)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,22 @@
+# NEAT v4.5.3
+
+Handle IUPAC ambiguity codes in the reference (issue #291).
+
+Reference assemblies such as GRCh38 carry IUPAC ambiguity codes (R, Y, S, W,
+K, M, B, D, H, V) alongside A/C/G/T/N. NEAT previously had no handling: such a
+base could survive reference loading and then crash a run with a `KeyError`
+when it landed at a sequencing-error site (the substitution model only indexes
+A/C/G/T).
+
+- Ambiguity codes are now resolved to a concrete base — one of the bases the
+  code represents, chosen with the run's seeded RNG — when the reference is
+  loaded. Every downstream consumer (reads, BAM, golden VCF, error and
+  trinucleotide lookups) therefore only ever sees A/C/G/T/N, and a count of
+  resolved bases is logged per contig. `N` keeps its existing low-quality
+  masking behavior.
+- Defense-in-depth: the sequencing-error model now skips a non-A/C/G/T
+  reference base instead of raising, so no unmapped base can crash a run.
+
 # NEAT v4.5.2
 
 Fixed coverage handling at low and fractional depths (issue #242).

--- a/neat/common/constants_and_defaults.py
+++ b/neat/common/constants_and_defaults.py
@@ -1,3 +1,4 @@
+import numpy as np
 from frozendict import frozendict
 
 LOW_COVERAGE_THRESHOLD = 50
@@ -9,6 +10,53 @@ Constants needed for analysis
 # allowed nucleotides sets not only the allowed letters, but their order for sampling purposes.
 ALLOWED_NUCL = ['A', 'C', 'G', 'T']
 NUC_IND = frozendict({'A': 0, 'C': 1, 'G': 2, 'T': 3, 'a': 0, 'c': 1, 'g': 2, 't': 3})
+
+# IUPAC ambiguity codes mapped to the concrete bases they represent. NEAT resolves each
+# occurrence to one of these bases (chosen with the run's seeded RNG) when the reference is
+# loaded, so the rest of the pipeline — reads, BAM, golden VCF, error/trinucleotide lookups —
+# only ever sees A/C/G/T/N and never crashes on an unmapped base. 'N' is intentionally NOT
+# listed: it keeps its existing handling (masked to a low-quality telomere-repeat filler in
+# Read.convert_masking) rather than being resolved to a definite base.
+IUPAC_CODES = frozendict({
+    'R': ('A', 'G'), 'Y': ('C', 'T'), 'S': ('C', 'G'), 'W': ('A', 'T'),
+    'K': ('G', 'T'), 'M': ('A', 'C'),
+    'B': ('C', 'G', 'T'), 'D': ('A', 'G', 'T'), 'H': ('A', 'C', 'T'), 'V': ('A', 'C', 'G'),
+})
+
+
+def resolve_iupac_bases(sequence: str, rng) -> tuple[str, int]:
+    """
+    Replace IUPAC ambiguity codes in an (uppercased) sequence with concrete bases.
+
+    Each ambiguity code (R, Y, S, W, K, M, B, D, H, V) is replaced with one of the bases it
+    represents, chosen uniformly with the run's seeded RNG. Standard bases (A/C/G/T) and 'N'
+    are left untouched — 'N' retains its downstream low-quality masking. Reference assemblies
+    such as GRCh38 carry a handful of these codes; resolving them at load time guarantees the
+    rest of the pipeline only sees A/C/G/T/N and never raises on an unmapped base.
+
+    The common case (no ambiguity codes present) returns the input unchanged after a single
+    vectorized scan, so genome-scale references are not penalized.
+
+    :param sequence: An uppercased nucleotide sequence.
+    :param rng: The run's seeded numpy Generator.
+    :return: (resolved_sequence, number_of_bases_resolved)
+    """
+    arr = np.frombuffer(sequence.encode("ascii"), dtype=np.uint8)
+    code_bytes = np.fromiter((ord(c) for c in IUPAC_CODES), dtype=np.uint8)
+    mask = np.isin(arr, code_bytes)
+    if not mask.any():
+        return sequence, 0
+
+    arr = arr.copy()
+    n_resolved = 0
+    for code, bases in IUPAC_CODES.items():
+        positions = np.where(arr == ord(code))[0]
+        if positions.size == 0:
+            continue
+        base_bytes = np.fromiter((ord(b) for b in bases), dtype=np.uint8)
+        arr[positions] = base_bytes[rng.integers(len(bases), size=positions.size)]
+        n_resolved += int(positions.size)
+    return arr.tobytes().decode("ascii"), n_resolved
 
 MAX_ATTEMPTS = 100  # max attempts to insert a mutation into a valid position
 MAX_MUTFRAC = 0.3  # the maximum percentage of a window that can contain mutations

--- a/neat/models/error_models.py
+++ b/neat/models/error_models.py
@@ -253,7 +253,13 @@ class SequencingErrorModel(SnvModel, DeletionModel, InsertionModel):
             # else dedicated to SNVs.
             else:
                 snv_reference = reference_segment[index]
-                nuc_index = NUC_IND[snv_reference]
+                nuc_index = NUC_IND.get(snv_reference)
+                if nuc_index is None:
+                    # Reference base is not A/C/G/T (e.g. an unresolved IUPAC code or an 'N'
+                    # that slipped through). IUPAC codes are normally resolved at reference
+                    # load (see resolve_iupac_bases), so this is a safety net: skip the error
+                    # at this position rather than raising a KeyError on the lookup.
+                    continue
                 # take the zero index because this returns a list of length 1.
                 snv_alt = rng.choice(ALLOWED_NUCL, p=self.transition_matrix[nuc_index])
                 introduced_errors.append(

--- a/neat/read_simulator/utils/split_inputs.py
+++ b/neat/read_simulator/utils/split_inputs.py
@@ -17,6 +17,7 @@ from Bio import bgzf, SeqIO
 from Bio.Seq import Seq
 
 from neat.read_simulator.utils import Options
+from neat.common import resolve_iupac_bases
 
 _LOG = logging.getLogger(__name__)
 
@@ -71,6 +72,16 @@ def main(options: Options) -> tuple[dict, int, dict]:
     for seq_record in SeqIO.parse(str(options.reference), "fasta"):
         contig = seq_record.id
         seq_str = str(seq_record.seq).upper()
+        # Resolve any IUPAC ambiguity codes (R, Y, S, W, K, M, B, D, H, V) to a concrete
+        # base now, so every downstream consumer (reads, BAM, golden VCF, error and
+        # trinucleotide lookups) only ever sees A/C/G/T/N. 'N' is left for its existing
+        # low-quality masking. References like GRCh38 carry a handful of these codes.
+        seq_str, n_ambiguous = resolve_iupac_bases(seq_str, options.rng)
+        if n_ambiguous:
+            _LOG.warning(
+                f"Resolved {n_ambiguous} IUPAC ambiguity code(s) to concrete bases on "
+                f"contig '{contig}'."
+            )
         reference_keys_with_lens[contig] = len(seq_str)
         split_fasta_dict[contig] = {}
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neat-genreads"
-version = "4.5.2"
+version = "4.5.3"
 description = "NGS Simulation toolkit"
 readme = "README.md"
 authors = ["Joshua Allen <jallen17@illinois.edu>", "Keshav Gandhi <krg3@illinois.edu>"]

--- a/tests/test_common/test_iupac.py
+++ b/tests/test_common/test_iupac.py
@@ -1,0 +1,82 @@
+"""
+Tests for IUPAC ambiguity-code resolution (issue #291).
+"""
+import numpy as np
+from numpy.random import default_rng
+
+from neat.common.constants_and_defaults import IUPAC_CODES, resolve_iupac_bases
+
+
+def test_no_ambiguity_codes_returns_unchanged():
+    """A plain A/C/G/T/N sequence is returned untouched with a zero count."""
+    seq = "ACGTACGTNNNNACGT"
+    out, n = resolve_iupac_bases(seq, default_rng(0))
+    assert out == seq
+    assert n == 0
+
+
+def test_n_is_not_resolved():
+    """'N' is deliberately left alone (it has its own downstream masking)."""
+    seq = "N" * 50
+    out, n = resolve_iupac_bases(seq, default_rng(1))
+    assert out == seq
+    assert n == 0
+
+
+def test_every_code_resolves_into_its_allowed_set():
+    """Each ambiguity code is replaced by one of the bases it represents."""
+    rng = default_rng(7)
+    for code, bases in IUPAC_CODES.items():
+        seq = code * 200
+        out, n = resolve_iupac_bases(seq, rng)
+        assert n == 200
+        assert set(out) <= set(bases), f"{code} produced bases outside {bases}: {set(out)}"
+        # Sanity: nothing left unresolved.
+        assert code not in out
+
+
+def test_count_matches_number_of_codes():
+    """The returned count equals the number of ambiguity positions resolved."""
+    seq = "ACGTRYSWKMACGTBDHVN"  # 10 ambiguity codes embedded
+    out, n = resolve_iupac_bases(seq, default_rng(3))
+    assert n == 10
+    # Only A/C/G/T/N remain.
+    assert set(out) <= set("ACGTN")
+    # The N is preserved in place (last char).
+    assert out[-1] == "N"
+
+
+def test_resolution_is_reproducible_with_seed():
+    """Same seed → identical resolution."""
+    seq = "RYSWKMBDHV" * 100
+    a, na = resolve_iupac_bases(seq, default_rng(99))
+    b, nb = resolve_iupac_bases(seq, default_rng(99))
+    assert a == b
+    assert na == nb == 1000
+
+
+def test_mixed_distribution_covers_both_alternatives():
+    """Over many positions, a 2-base code resolves to both of its options."""
+    seq = "R" * 1000
+    out, _ = resolve_iupac_bases(seq, default_rng(2024))
+    assert set(out) == {"A", "G"}, f"expected both A and G, got {set(out)}"
+
+
+def test_length_preserved():
+    """Resolution never changes sequence length."""
+    seq = "ACGTRYSWKMNBDHV"
+    out, _ = resolve_iupac_bases(seq, default_rng(5))
+    assert len(out) == len(seq)
+
+
+def test_lowercase_not_resolved():
+    """Resolution operates on uppercased input; lowercase ambiguity codes pass through.
+
+    The caller (split_inputs) uppercases before calling, so this just documents that the
+    function itself only acts on the canonical uppercase codes and won't silently mangle
+    unexpected input.
+    """
+    seq = "rystACGT"
+    out, n = resolve_iupac_bases(seq, default_rng(0))
+    assert out == seq
+    assert n == 0

--- a/tests/test_read_simulator/test_runner.py
+++ b/tests/test_read_simulator/test_runner.py
@@ -290,6 +290,34 @@ def test_runner_produces_fastq_output(tmp_path):
     assert first_line.startswith("@"), "FASTQ file should start with '@'"
 
 
+def test_runner_handles_iupac_ambiguity_codes(tmp_path):
+    """A reference with IUPAC ambiguity codes runs end-to-end without crashing, and the
+    FASTQ output contains only A/C/G/T/N — the codes are resolved at load (issue #291)."""
+    # 400 bp with every ambiguity code embedded, plus a 10 bp N run.
+    seq = list("ACGT" * 100)
+    for i, code in enumerate("RYSWKMBDHV"):
+        seq[i * 10] = code          # scatter the 10 ambiguity codes
+    seq[200:210] = list("N" * 10)   # also exercise the N-masking path
+    ref = tmp_path / "ref.fa"
+    ref.write_text(">chr1\n" + "".join(seq) + "\n", encoding="utf-8")
+
+    cfg = _write_config(tmp_path / "conf.yml", ref, read_len=50, coverage=20)
+    out_dir = tmp_path / "out"
+
+    read_simulator_runner(str(cfg), str(out_dir), "test")  # must not raise
+
+    fq_files = list(out_dir.glob("*.fastq.gz"))
+    assert fq_files, "Expected FASTQ output"
+    read_seqs = []
+    with gzip.open(fq_files[0], "rt") as fh:
+        for i, line in enumerate(fh):
+            if i % 4 == 1:
+                read_seqs.append(line.strip())
+    assert read_seqs, "Expected at least one read"
+    leaked = set("".join(read_seqs)) - set("ACGTN")
+    assert not leaked, f"FASTQ leaked non-ACGTN bases from IUPAC reference: {sorted(leaked)}"
+
+
 def test_runner_paired_end_produces_two_fastqs(tmp_path):
     """Paired-end mode produces both fq1 and fq2."""
     ref = _write_ref(tmp_path / "ref.fa")


### PR DESCRIPTION
Fixes #291. **Release v4.5.3** (version bump + ChangeLog entry included).

## Problem
GRCh38 and other assemblies carry IUPAC ambiguity codes (`R Y S W K M B D H V`) alongside `A/C/G/T/N`. NEAT had no handling:
- They survived reference load — `Read.convert_masking()` only neutralized non-ACGT bases when the segment *also* contained an `N`, and skipped bases before the first `N`.
- A surviving code at a sequencing-error site hit `NUC_IND[snv_reference]` (`error_models.py:256`); `NUC_IND` only has A/C/G/T → **`KeyError`**, aborting the run.

(Mutation generation was already safe — skips non-`ALLOWED_NUCL` positions — and the BAM SEQ encoder already supports IUPAC nibbles. The crash was specific to the sequencing-error path.)

## Fix
Resolve ambiguity codes to a concrete base **at reference load**, so every downstream consumer (reads, BAM, golden VCF, error/trinucleotide lookups) only ever sees `A/C/G/T/N`.

- **`common`**: `IUPAC_CODES` map + `resolve_iupac_bases()` — replaces each code with one of the bases it represents using the run's seeded RNG (reproducible). Vectorized; the no-codes common case is a single scan, so genome-scale references aren't penalized. `N` is left for its existing low-quality masking.
- **`split_inputs`**: resolves right after the existing `.upper()`; logs a warning with the count.
- **`error_models`**: defense-in-depth — `NUC_IND` lookup skips a non-ACGT base instead of raising, so nothing can crash even if a code slips through.

## Release
- `pyproject.toml`: `4.5.2 → 4.5.3`
- `ChangeLog.md`: new `# NEAT v4.5.3` entry for the #291 fix

(Branch is rebased on current `develop` at 4.5.2, so the bump applies cleanly.)

## Tests
- Resolver unit tests: every code resolves into its allowed set, counts, reproducibility, `N` left alone, length preserved, lowercase passthrough.
- End-to-end runner test on a reference with all ten codes + an N run, asserting FASTQ output is clean.

Full suite: **790 passed, 3 skipped**. Verified end-to-end (single- and multi-threaded) on a synthetic IUPAC reference: no crash; FASTQ/BAM/VCF outputs contain only A/C/G/T/N.

## Known limitation
The input-VCF ref-match check (`vcf_func.py:137`) reads the original reference file, not the resolved chunks — it won't crash (string comparison), but at an ambiguous position an input variant is matched against the original code while reads show the resolved base. Rare edge case; left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)